### PR TITLE
refactor: match icon colors with old repo and clean up input control …

### DIFF
--- a/apps/client/src/module/common/controlled-input.tsx
+++ b/apps/client/src/module/common/controlled-input.tsx
@@ -50,7 +50,7 @@ export function ControlledTextInput<TFieldValues extends object>({
 
   return (
     <label className={inputVariants({ direction })}>
-      <span className="text-[13px]">
+      <span>
         {label}
         {!!tooltips && direction === "vertical" && (
           <span className="text-accent-400 hidden group-focus-within:inline">
@@ -60,13 +60,13 @@ export function ControlledTextInput<TFieldValues extends object>({
       </span>
       <div className={clsx(!!tooltips && "flex flex-col")}>
         {!!tooltips && direction === "horizontal" && (
-          <span className="text-accent-400 hidden space-y-1 text-[13px] group-focus-within:inline">
+          <span className="text-accent-400 hidden space-y-1 group-focus-within:inline">
             {tooltips}
           </span>
         )}
         <div className="relative flex items-stretch">
           {!!leftElement && (
-            <span className="bg-primary-100 text-primary-300 p-2 transition-colors duration-300 dark:bg-neutral-700">
+            <span className="bg-primary-100 text-primary-300 p-2 transition-colors duration-300 dark:bg-[#33333a]">
               {leftElement}
             </span>
           )}


### PR DESCRIPTION

<!-- link to tickets -->
[CP-115](https://beequant.atlassian.net/browse/CP-115?atlOrigin=eyJpIjoiNjZjMDExOTg5NTU0NDRhMmI2NWE0Yzc4NWE1NWYyZTMiLCJwIjoiaiJ9)

---

## What happens here?
![image](https://github.com/user-attachments/assets/a417d949-a717-4896-9395-196884d6701b)

I changed the previous `neutral-800` color to the color `#33333A` from the legacy repository.

## How do I know this is working?
Yeah just run it I think, and then check the old one.

## Any notes?
`#33333A` doesn't exist in our color scale so I use an arbitrary value.

<!--
  New PR Checklist

- Have you tag the right reviewer?
- Have you dm the reviewer?
- Maybe @ the reviewer in channel just to be safe

- is CI passing in your pr?
- Have you update the ticket with the right status?
-->
