### PR TITLE
fix: Replace Icons to Match Legacy Repo Styles

### DIFF
--- a/apps/client/src/module/common/controlled-input.tsx
+++ b/apps/client/src/module/common/controlled-input.tsx
@@ -110,7 +110,7 @@ export function ControlledPasswordInput<TFieldValues extends object>({
       rightElement={
         showPassword ? (
           <button
-            className="bg-accent-400 text-primary-50 p-2"
+            className="bg-accent-600 text-primary-50 p-2"
             type="button"
             onClick={() => toggleShowPassword()}
           >
@@ -118,7 +118,7 @@ export function ControlledPasswordInput<TFieldValues extends object>({
           </button>
         ) : (
           <button
-            className="bg-accent-400 text-primary-50 p-2"
+            className="bg-accent-300 text-primary-50 hover:bg-accent-400 p-2"
             type="button"
             onClick={() => toggleShowPassword()}
           >


### PR DESCRIPTION
Fixed the Show Password Icon Animation

Resolve CP-116

fix/CP-116-Replace-Icons-to-Match-Legacy-Repo-Styles

<!-- link to tickets -->

---

## What happens here?

## How do I know this is working?

## Any notes?

<!--
  New PR Checklist

- Have you tag the right reviewer?
- Have you dm the reviewer?
- Maybe @ the reviewer in channel just to be safe

- is CI passing in your pr?
- Have you update the ticket with the right status?
-->
