### PR TITLE
update: enhance zod schema validation for Login and Register pages

### DIFF
--- a/apps/client/src/module/account/change/password/change-password-form.tsx
+++ b/apps/client/src/module/account/change/password/change-password-form.tsx
@@ -14,15 +14,11 @@ import {
 import { Modal } from "@src/module/common/modal";
 import { useRef } from "react";
 import { logout } from "@src/module/auth";
+import { passwordValidationSchema } from "@src/utils/validation-schema";
 
 export function ChangePasswordForm() {
   const t = useTranslations();
-  const passwordSchema = z
-    .string()
-    .min(1, { message: t("Notifications.password.required") })
-    .min(8, { message: t("Notifications.password.minLength") })
-    .max(32, { message: t("Notifications.password.maxLength") })
-    .regex(passwordPatten, { message: t("Notifications.password.invalid") });
+  const passwordSchema = passwordValidationSchema(t);
 
   const updatePasswordSchema = z
     .object({

--- a/apps/client/src/module/auth/login-form.tsx
+++ b/apps/client/src/module/auth/login-form.tsx
@@ -17,23 +17,28 @@ import { login, LoginPayload } from "./auth-service";
 import { AuthRoute } from "./route";
 import { useTranslations } from "next-intl";
 
-type LoginForm = z.infer<typeof formSchema>;
-// source of truth for this login form <= this is the law, is the king, is the absolute authority for this form - K总
-const formSchema = z.object({
-  email: z.string().email(),
-  password: z.string().min(8),
-  remeber: z.string(),
-});
-
-// Need this to enforce default value to match the LoginForm schema, because if you do it in the `useForm` hook, it turns it into a `Partial<LoginForm>` type.
-const defaultValues = {
-  email: "",
-  password: "",
-  remeber: "",
-} satisfies LoginForm; // Satifies make sure this object you are making can satisfy the LoginForm schema.
-
 export function LoginForm() {
   const t = useTranslations();
+
+  type LoginForm = z.infer<typeof formSchema>;
+  // source of truth for this login form <= this is the law, is the king, is the absolute authority for this form - K总
+
+  const formSchema = z.object({
+    email: z
+        .string()
+        .min(1, { message: t("Notifications.email.required") })
+        .email({ message: t("Notifications.email.invalid") }),
+    password: z.string()
+      .min(1, { message: t("Notifications.password.required") }),
+    remember: z.string(),
+  });
+
+  // Need this to enforce default value to match the LoginForm schema, because if you do it in the `useForm` hook, it turns it into a `Partial<LoginForm>` type.
+  const defaultValues = {
+    email: "",
+    password: "",
+    remember: "",
+  } satisfies LoginForm; // Satifies make sure this object you are making can satisfy the LoginForm schema.
   const router = useRouter();
   const {
     handleSubmit,

--- a/apps/client/src/utils/validation-schema.ts
+++ b/apps/client/src/utils/validation-schema.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+import { passwordPatten } from "@src/utils/validation-message";
+
+export const passwordValidationSchema = (t: (key: string) => string) => {
+    return z.string()
+        .min(1, { message: t("Notifications.password.required") })
+        .min(8, { message: t("Notifications.password.minLength") })
+        .max(32, { message: t("Notifications.password.maxLength") })
+        .regex(passwordPatten, { message: t("Notifications.password.invalid") });
+};


### PR DESCRIPTION
Resolved CP-126

[CP-126](https://beequant.atlassian.net/jira/software/projects/CP/boards/1?selectedIssue=CP-126)

---

## What happens here?
- update schema for the login page to ensure 'email' conforms to the standard and 'password' is not empty.
- update the schema for the registration page to ensure all fields conform to the standards and 'confirmPassword' matches 'password'.
- add multilingual support.
- add passwordSchema in 'utils' for reuse.

## How do I know this is working?
- when the user enters an invalid email address or leaves the password field empty on login page, a prompt message will appear.
<img width="538" alt="image" src="https://github.com/user-attachments/assets/9e271ec8-ce18-40f5-95e9-079bdef7a8a8">

- when the user inputs data that does not meet the standards on register page, a message will be displayed
- if the confirm password does not match the password, the message will be shown
<img width="537" alt="image" src="https://github.com/user-attachments/assets/7ca4d924-6a90-4a54-9444-4c24381d7a39">


## Any notes?

<!--
  New PR Checklist

- Have you tag the right reviewer?
- Have you dm the reviewer?
- Maybe @ the reviewer in channel just to be safe

- is CI passing in your pr?
- Have you update the ticket with the right status?
-->
