### PR TITLE
feat: add password reset process pages

### DIFF
--- a/apps/client/messages/en.json
+++ b/apps/client/messages/en.json
@@ -56,6 +56,17 @@
     }
   },
 
+  "ForgotPasswordPage": {
+    "forgetPasswordTitle": "Enter Your Email",
+    "resetPasswordTitle": "Reset Password",
+    "backTo": "Back to ",
+    "succeed": {
+      "title": "Cool !",
+      "message": "Your password has been reset",
+      "backToLogin": "Back to login"
+    }
+  },
+
   "Sidebar": {
     "dashboard": "Dashboard",
     "bots": {
@@ -134,6 +145,11 @@
     },
     "secretKey": {
       "required": "Secret key is required"
+    },
+    "forgotPassword": {
+      "emailRequestSuccess": "If the email is associated with an account, a reset email will be sent shortly. Please check your mailbox.",
+      "tokenInvalid": "Reset password link is invalid or expired. Please back to Login page and click ' Forgot password? ' to receive a new reset link.",
+      "resetPasswordError": "An error occurred while processing your request. Please try again later."
     }
   },
 

--- a/apps/client/messages/zh-cn.json
+++ b/apps/client/messages/zh-cn.json
@@ -56,6 +56,17 @@
     }
   },
 
+  "ForgotPasswordPage": {
+    "forgetPasswordTitle": "请输入邮箱",
+    "resetPasswordTitle": "重置密码",
+    "backTo": "返回",
+    "succeed": {
+      "title": "太棒了!",
+      "message": "您的密码已成功重置",
+      "backToLogin": "返回登录"
+      }
+    },
+
   "Sidebar": {
     "dashboard": "中控台",
     "bots": {
@@ -131,6 +142,11 @@
     },
     "secretKey": {
       "required": "API密钥是必填项"
+    },
+    "forgotPassword": {
+      "emailRequestSuccess": "如果该邮箱与现有账户关联，重置邮件将会发送到您的邮箱，请查收。",
+      "tokenInvalid": "重置密码链接无效或已过期。请返回登录页面，点击'忘记密码？'以获取新的重置链接。",
+      "resetPasswordError": "请求处理过程中出现错误，请稍后重试。"
     }
   },
 

--- a/apps/client/src/app/[locale]/(auth)/forgot-password/page.tsx
+++ b/apps/client/src/app/[locale]/(auth)/forgot-password/page.tsx
@@ -1,0 +1,7 @@
+import { AuthRoute, ForgotPasswordForm } from "@src/module/auth";
+
+export const metadata = AuthRoute.ForgetPassword.Metadata;
+
+export default function Page() {
+    return <ForgotPasswordForm />;
+  }

--- a/apps/client/src/app/[locale]/(auth)/reset-password/page.tsx
+++ b/apps/client/src/app/[locale]/(auth)/reset-password/page.tsx
@@ -1,0 +1,9 @@
+import { AuthRoute, ResetPasswordForm } from "@src/module/auth";
+
+export const metadata = AuthRoute.ResetPassword.Metadata;
+
+export default function Page({ searchParams }: {
+  searchParams: { [key: string]: string | undefined }
+}) {
+  return <ResetPasswordForm searchParams={searchParams} />;
+}

--- a/apps/client/src/middleware.ts
+++ b/apps/client/src/middleware.ts
@@ -11,7 +11,7 @@ const handleI18Routing = createMiddleware({
 export async function middleware(request: NextRequest) {
   const token = request.cookies.get("token");
   const pathname = request.nextUrl.pathname;
-  const pagesWithoutToken = ["login", "register", "landing", "verify-email"];
+  const pagesWithoutToken = ["login", "register", "landing", "verify-email", "forgot-password", "reset-password"];
   const pagesRegex = new RegExp(
     `^\/(?:en|zh-cn)?\/?(?:${pagesWithoutToken.join("|")})$`,
   );

--- a/apps/client/src/module/auth/auth-form-container.tsx
+++ b/apps/client/src/module/auth/auth-form-container.tsx
@@ -4,16 +4,19 @@ type Props = {
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   error?: string;
   children: React.ReactNode;
+  title?: string;
 };
 export function AuthFormContainer(props: Props) {
   const t = useTranslations();
+  const defaultTitle = t("Shared.welcome");
+
   return (
     <form
       className="dark:bg-primary-900 bg-primary-50 flex w-full max-w-[520px] flex-col gap-5 px-[60px] py-[50px] transition-colors duration-300 max-sm:px-[30px] max-sm:py-[35px]"
       onSubmit={props.onSubmit}
     >
       <div className="border-accent-400 flex flex-col border-l-4 px-2.5">
-        <span className="text-2xl">{t("Shared.welcome")}</span>
+        <span className="text-2xl">{props.title || defaultTitle}</span>
         <span className="text-2xl font-bold tracking-wide">
           {t("Shared.beequant")}
           <span className="text-accent-400">{t("Shared.ai")}</span>

--- a/apps/client/src/module/auth/auth-service.ts
+++ b/apps/client/src/module/auth/auth-service.ts
@@ -1,6 +1,7 @@
 "use server";
 import {
   CreateUserInput,
+  ResetPasswordInput,
   getServerGqlClient,
   graphql,
 } from "@src/module/graphql";
@@ -41,6 +42,7 @@ export async function login(payload: LoginPayload) {
 
     case 10003:
     case 10010:
+    case 10017:
     default:
       return {
         error: login.message,
@@ -74,6 +76,7 @@ export async function register(input: RegisterPayload) {
 
     case 10004:
     case 10005:
+    case 10017:
     default:
       return {
         error: register.message,
@@ -105,6 +108,7 @@ export async function verifyEmail(payload: VerifyEmailPayload) {
         success: true,
       };
     case 10011:
+    case 10017:
       return {
         error: verifyEmail.message,
       };
@@ -132,3 +136,68 @@ export async function logout() {
 
   redirect(AuthRoute.Login.Path);
 }
+
+const forgotPasswordMutation = graphql(`
+  mutation ForgotPassword($email: String!){
+    forgotPassword(email: $email) {
+      code
+      message
+      data
+    }
+  }
+`);
+
+export type ForgotPasswordPayload = {
+  email: string;
+};
+
+export async function forgotPassword(payload: ForgotPasswordPayload) {
+  const gqlClient = await getServerGqlClient();
+  const { forgotPassword } = await gqlClient.request(forgotPasswordMutation, payload);
+
+  switch (forgotPassword.code) {
+    case 200:
+      return {
+        success: forgotPassword.message,
+      };
+      
+    case 10016:
+    case 10017:
+    default:
+      return {
+        error: forgotPassword.message,
+      };
+  }
+}
+
+const resetPasswordMutation = graphql(`
+  mutation resetPassword($input: ResetPasswordInput!){
+    resetPassword(input: $input) {
+      code
+      message
+      data
+    }
+  }
+`);
+
+export type ResetPasswordPayload = ResetPasswordInput;
+export async function resetPassword(input: ResetPasswordPayload) {
+  const gqlClient = await getServerGqlClient();
+  const { resetPassword } = await gqlClient.request(resetPasswordMutation, {
+    input,
+  });
+
+  switch (resetPassword.code) { 
+    case 200:
+      return {
+        success: true,
+      };
+
+    case 10016:
+    default:
+      return {
+        error: resetPassword.message,
+      };
+  }
+}
+

--- a/apps/client/src/module/auth/forgot-password-form.tsx
+++ b/apps/client/src/module/auth/forgot-password-form.tsx
@@ -1,0 +1,87 @@
+"use client";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+    Button,
+    ControlledTextInput,
+    Icon,
+} from "@src/module/common";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { AuthFormContainer } from "./auth-form-container";
+import { forgotPassword, ForgotPasswordPayload } from "./auth-service";
+import { AuthRoute } from "./route";
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+
+export function ForgotPasswordForm() {
+    const t = useTranslations();
+
+    type FormSchema = z.infer<typeof formSchema>;
+    const formSchema = z.object({
+        email: z
+        .string()
+        .min(1, { message: t("Notifications.email.required") })
+        .email({ message: t("Notifications.email.invalid") })
+    });
+
+    const [successMessage, setSuccessMessage] = useState('');
+    
+    const {
+        handleSubmit,
+        control,
+        formState: { errors },
+        setError,
+    } = useForm<FormSchema>({
+        defaultValues: {
+            email: "",
+        },
+        resolver: zodResolver(formSchema),
+    });
+
+    async function action(payload: ForgotPasswordPayload) {
+        const res = await forgotPassword(payload);
+
+        if (res?.success || res?.error === "account doesn't exist") {
+            setSuccessMessage(t("Notifications.forgotPassword.emailRequestSuccess"));
+        }
+        else { 
+            setError("root", { message: t("Notifications.forgotPassword.resetPasswordError") });
+            console.error('Error during password reset request:', res?.error);
+        }
+    }
+
+    const onSubmit = handleSubmit((data) => {
+        setSuccessMessage('');
+        action(data);
+    });
+
+    return (
+        <AuthFormContainer
+            onSubmit={onSubmit}
+            error={errors.root?.message}
+            title={t("ForgotPasswordPage.forgetPasswordTitle")}
+        >
+            {successMessage && (
+                <div className="text-accent-400 hover:text-accent-400">{successMessage}</div>
+            )}
+            <ControlledTextInput
+                label={t("Shared.email")}
+                name="email"
+                control={control}
+                leftElement={<Icon icon="person" />}
+                autoComplete="email"
+            />
+
+            <Button type="submit" className="my-5">
+                {t("Shared.submit")}
+            </Button>
+
+            <span className="text-center text-[13px]">
+                {t("ForgotPasswordPage.backTo")}
+                <AuthRoute.Login.Link className="text-accent-400 hover:text-accent-400">
+                    {t("Shared.signIn")}
+                </AuthRoute.Login.Link>
+            </span>
+        </AuthFormContainer>
+    );
+}

--- a/apps/client/src/module/auth/index.ts
+++ b/apps/client/src/module/auth/index.ts
@@ -3,3 +3,5 @@ export * from "./login-form";
 export * from "./register-form";
 export * from "./route";
 export * from "./verify-email-page";
+export * from "./forgot-password-form";
+export * from "./reset-password-form";

--- a/apps/client/src/module/auth/reset-password-form.tsx
+++ b/apps/client/src/module/auth/reset-password-form.tsx
@@ -1,0 +1,121 @@
+"use client";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+    Button,
+    ControlledPasswordInput,
+} from "@src/module/common";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { AuthFormContainer } from "./auth-form-container";
+import { resetPassword, ResetPasswordPayload } from "./auth-service";
+import { AuthRoute } from "./route";
+import { useTranslations } from "next-intl";
+import { passwordValidationSchema } from "@src/utils/validation-schema";
+import { useState } from "react";
+import { Successed } from "@src/module/common";
+
+type ResetPasswordFormProps = {
+    searchParams: { [key: string]: string | undefined }
+};
+
+export function ResetPasswordForm({ searchParams }: ResetPasswordFormProps) {
+    const t = useTranslations();
+    const passwordSchema = passwordValidationSchema(t);
+    const [isSuccess, setIsSuccess] = useState(false);
+
+    type FormSchema = z.infer<typeof formSchema>;
+    const formSchema = z
+        .object({
+            password: passwordSchema,
+            confirmPassword: passwordSchema,
+        })
+        .refine((data) => data.password === data.confirmPassword, {
+            message: t("Notifications.password.notMatch"),
+            path: ["confirmPassword"],
+        });
+
+    const {
+        handleSubmit,
+        control,
+        formState: { errors },
+        setError,
+    } = useForm<FormSchema>({
+        defaultValues: {
+            password: "",
+            confirmPassword: "",
+        },
+        resolver: zodResolver(formSchema),
+    });
+
+    async function action(payload: ResetPasswordPayload) {
+        const res = await resetPassword(payload);
+
+        if (res?.success) {
+            setIsSuccess(true);
+        }
+        else if (res?.error === "Token has expired" || res?.error === "Invalid reset password token") {
+            setError("root", { message: t("Notifications.forgotPassword.tokenInvalid") });
+        }
+        else if (res?.error) {
+            setError("root", { message: t("Notifications.forgotPassword.resetPasswordError") });
+            console.error('Error during password reset request:', res?.error);
+        }
+    }
+
+    const onSubmit = handleSubmit((data) => {
+        const extractedToken = searchParams.token;
+    
+        if (typeof extractedToken === 'string'){
+            action({
+                newPassword: data.password,
+                resetToken: extractedToken,
+            });
+        }
+        else {
+            setError("root", { message: t("Notifications.forgotPassword.tokenInvalid") });
+        }
+    });
+
+    if (isSuccess) {
+        return (
+            <Successed
+                title={t("ForgotPasswordPage.succeed.title")}
+                message={t("ForgotPasswordPage.succeed.message")}
+                state="success"
+            />
+        );
+    }
+
+    return (
+        <AuthFormContainer
+            onSubmit={onSubmit}
+            error={errors.root?.message}
+            title={t("ForgotPasswordPage.resetPasswordTitle")}
+        >
+            <ControlledPasswordInput
+                label={t("Shared.password")}
+                tooltips={t("Notifications.password.description")}
+                name="password"
+                control={control}
+                autoComplete="new-password"
+            />
+            <ControlledPasswordInput
+                label={t("Shared.confirmPassword")}
+                name="confirmPassword"
+                control={control}
+                autoComplete="new-password"
+            />
+
+            <Button type="submit" className="my-5">
+                {t("Shared.submit")}
+            </Button>
+
+            <span className="text-center text-[13px]">
+                {t("ForgotPasswordPage.backTo")}
+                <AuthRoute.Login.Link className="text-accent-400 hover:text-accent-400">
+                    {t("Shared.signIn")}
+                </AuthRoute.Login.Link>
+            </span>
+        </AuthFormContainer>
+    );
+}

--- a/apps/client/src/module/auth/route.tsx
+++ b/apps/client/src/module/auth/route.tsx
@@ -41,6 +41,18 @@ const ForgetPassword = {
   ),
 };
 
+const ResetPassword = {
+  Metadata: {
+    title: "Reset Password | BeeQuant",
+  },
+  Path: "/reset-password" as const,
+  Link: ({ children, className }: RouteLinkProps) => (
+    <Link href={ResetPassword.Path} className={className}>
+      {children}
+    </Link>
+  ),
+};
+
 const VerifyEmail = {
   Metadata: {
     title: "Verify Email | BeeQuant",
@@ -57,5 +69,6 @@ export const AuthRoute = {
   Login,
   Register,
   ForgetPassword,
+  ResetPassword,
   VerifyEmail,
 };

--- a/apps/client/src/module/graphql/codegen/gql.ts
+++ b/apps/client/src/module/graphql/codegen/gql.ts
@@ -18,6 +18,8 @@ const documents = {
     "\n  mutation Register($input: CreateUserInput!) {\n    register(input: $input) {\n      code\n      message\n    }\n  }\n": types.RegisterDocument,
     "\n  mutation VerifyEmail($email: String!, $token: String!) {\n    verifyEmail(email: $email, token: $token) {\n      code\n      message\n    }\n  }\n": types.VerifyEmailDocument,
     "\n  query getUserInfo {\n    getUserInfo {\n      id\n      displayName\n    }\n  }\n": types.GetUserInfoDocument,
+    "\n  mutation ForgotPassword($email: String!){\n    forgotPassword(email: $email) {\n      code\n      message\n      data\n    }\n  }\n": types.ForgotPasswordDocument,
+    "\n  mutation resetPassword($input: ResetPasswordInput!){\n    resetPassword(input: $input) {\n      code\n      message\n      data\n    }\n  }\n": types.ResetPasswordDocument,
     "\n  query GetExchangeKeyById($id: String!) {\n    getExchangeKeyById(id: $id) {\n      code\n      message\n      data {\n        displayName\n        accessKey\n        secretKey\n        exchangeName\n      }\n    }\n  }\n": types.GetExchangeKeyByIdDocument,
     "\n  mutation UpdateExchangeKey($input: UpdateExchangeKeyInput!) {\n    updateExchangeKey(input: $input) {\n      code\n      message\n    }\n  }\n": types.UpdateExchangeKeyDocument,
     "\n  mutation CreateExchangeKey($input: CreateExchangeKeyInput!) {\n    createExchangeKey(input: $input) {\n      code\n      message\n    }\n  }\n": types.CreateExchangeKeyDocument,
@@ -57,6 +59,14 @@ export function graphql(source: "\n  mutation VerifyEmail($email: String!, $toke
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n  query getUserInfo {\n    getUserInfo {\n      id\n      displayName\n    }\n  }\n"): (typeof documents)["\n  query getUserInfo {\n    getUserInfo {\n      id\n      displayName\n    }\n  }\n"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  mutation ForgotPassword($email: String!){\n    forgotPassword(email: $email) {\n      code\n      message\n      data\n    }\n  }\n"): (typeof documents)["\n  mutation ForgotPassword($email: String!){\n    forgotPassword(email: $email) {\n      code\n      message\n      data\n    }\n  }\n"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  mutation resetPassword($input: ResetPasswordInput!){\n    resetPassword(input: $input) {\n      code\n      message\n      data\n    }\n  }\n"): (typeof documents)["\n  mutation resetPassword($input: ResetPasswordInput!){\n    resetPassword(input: $input) {\n      code\n      message\n      data\n    }\n  }\n"];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/apps/client/src/module/graphql/codegen/graphql.ts
+++ b/apps/client/src/module/graphql/codegen/graphql.ts
@@ -76,6 +76,8 @@ export type Mutation = {
   createExchangeKey: Result;
   /** Create new user */
   createUser: Scalars['Boolean']['output'];
+  /** Delete exchange key by id */
+  deleteExchangeKey: Result;
   /** Hard delete an user */
   deleteUser: Scalars['Boolean']['output'];
   /** Forgot password */
@@ -107,6 +109,11 @@ export type MutationCreateExchangeKeyArgs = {
 
 export type MutationCreateUserArgs = {
   input: CreateUserInput;
+};
+
+
+export type MutationDeleteExchangeKeyArgs = {
+  exchangeKeyId: Scalars['String']['input'];
 };
 
 
@@ -300,6 +307,20 @@ export type GetUserInfoQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type GetUserInfoQuery = { __typename?: 'Query', getUserInfo: { __typename?: 'UserType', id: string, displayName: string } };
 
+export type ForgotPasswordMutationVariables = Exact<{
+  email: Scalars['String']['input'];
+}>;
+
+
+export type ForgotPasswordMutation = { __typename?: 'Mutation', forgotPassword: { __typename?: 'Result', code: number, message?: string | null, data?: string | null } };
+
+export type ResetPasswordMutationVariables = Exact<{
+  input: ResetPasswordInput;
+}>;
+
+
+export type ResetPasswordMutation = { __typename?: 'Mutation', resetPassword: { __typename?: 'Result', code: number, message?: string | null, data?: string | null } };
+
 export type GetExchangeKeyByIdQueryVariables = Exact<{
   id: Scalars['String']['input'];
 }>;
@@ -327,6 +348,8 @@ export const LoginDocument = {"kind":"Document","definitions":[{"kind":"Operatio
 export const RegisterDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"Register"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CreateUserInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"register"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"code"}},{"kind":"Field","name":{"kind":"Name","value":"message"}}]}}]}}]} as unknown as DocumentNode<RegisterMutation, RegisterMutationVariables>;
 export const VerifyEmailDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"VerifyEmail"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"email"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"token"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"verifyEmail"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"email"},"value":{"kind":"Variable","name":{"kind":"Name","value":"email"}}},{"kind":"Argument","name":{"kind":"Name","value":"token"},"value":{"kind":"Variable","name":{"kind":"Name","value":"token"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"code"}},{"kind":"Field","name":{"kind":"Name","value":"message"}}]}}]}}]} as unknown as DocumentNode<VerifyEmailMutation, VerifyEmailMutationVariables>;
 export const GetUserInfoDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"getUserInfo"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getUserInfo"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"displayName"}}]}}]}}]} as unknown as DocumentNode<GetUserInfoQuery, GetUserInfoQueryVariables>;
+export const ForgotPasswordDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ForgotPassword"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"email"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"forgotPassword"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"email"},"value":{"kind":"Variable","name":{"kind":"Name","value":"email"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"code"}},{"kind":"Field","name":{"kind":"Name","value":"message"}},{"kind":"Field","name":{"kind":"Name","value":"data"}}]}}]}}]} as unknown as DocumentNode<ForgotPasswordMutation, ForgotPasswordMutationVariables>;
+export const ResetPasswordDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"resetPassword"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ResetPasswordInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"resetPassword"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"code"}},{"kind":"Field","name":{"kind":"Name","value":"message"}},{"kind":"Field","name":{"kind":"Name","value":"data"}}]}}]}}]} as unknown as DocumentNode<ResetPasswordMutation, ResetPasswordMutationVariables>;
 export const GetExchangeKeyByIdDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetExchangeKeyById"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getExchangeKeyById"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"code"}},{"kind":"Field","name":{"kind":"Name","value":"message"}},{"kind":"Field","name":{"kind":"Name","value":"data"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"displayName"}},{"kind":"Field","name":{"kind":"Name","value":"accessKey"}},{"kind":"Field","name":{"kind":"Name","value":"secretKey"}},{"kind":"Field","name":{"kind":"Name","value":"exchangeName"}}]}}]}}]}}]} as unknown as DocumentNode<GetExchangeKeyByIdQuery, GetExchangeKeyByIdQueryVariables>;
 export const UpdateExchangeKeyDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateExchangeKey"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UpdateExchangeKeyInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updateExchangeKey"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"code"}},{"kind":"Field","name":{"kind":"Name","value":"message"}}]}}]}}]} as unknown as DocumentNode<UpdateExchangeKeyMutation, UpdateExchangeKeyMutationVariables>;
 export const CreateExchangeKeyDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateExchangeKey"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CreateExchangeKeyInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createExchangeKey"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"code"}},{"kind":"Field","name":{"kind":"Name","value":"message"}}]}}]}}]} as unknown as DocumentNode<CreateExchangeKeyMutation, CreateExchangeKeyMutationVariables>;


### PR DESCRIPTION
Resolves CP-28 & CP-121

[CP-28](https://beequant.atlassian.net/browse/CP-28) add forgot password process
[CP-121](https://beequant.atlassian.net/browse/CP-121) turbo migration

---

## What happens here?

- Implemented "Forgot Password" and "Reset Password" forms
- Created a Success Reset page to confirm successful password reset
- Added appropriate user guidance messages throughout the reset process
- Updated AuthFormContainer for reuse

### UI comparison
**Legacy:**
<img width="439" alt="image" src="https://github.com/user-attachments/assets/94f8b7da-6fd9-457e-bf56-2a9ffb8c7731">

**Turbo:**
<img width="540" alt="image" src="https://github.com/user-attachments/assets/2bfe7b99-04dc-4b06-97f2-a28b34c6b42c">

**Legacy:**
<img width="540" alt="image" src="https://github.com/user-attachments/assets/bcd5c0a6-1b3f-4be1-8395-123abaa19fe7">

**Turbo:**
<img width="600" alt="image" src="https://github.com/user-attachments/assets/c2405e9f-1be4-4b80-a511-707cd67e9553">

**Legacy:**
<img width="539" alt="image" src="https://github.com/user-attachments/assets/4f5e55e5-aa1d-43ff-83b1-6cbf44e1a841">

**Turbo:**
<img width="546" alt="image" src="https://github.com/user-attachments/assets/e5fbe4ac-d4dd-469b-a3e0-f6dcbd84cc79">


## How do I know this is working?
- For testing purposes, please switch the backend to the branch ‘**feat/CP28-reset-user-password**’ in platform_api repo.
- When the user clicks the "Forgot password" text on the login page, they are directed to the Reset Password Initiation Page, which will prompt them to enter their registered email address.
![image](https://github.com/user-attachments/assets/88222198-5e9a-4172-8a81-2c9fa16660e4)
- After submission, the system will display the message "If the email is associated with an account, a reset email will be sent shortly. Please check your mailbox," guiding the user to check their email for the reset link. If an error occurs during the request, the message "An error occurred while processing your request. Please try again later." will be shown.
![image](https://github.com/user-attachments/assets/38a0eb43-461c-4ec5-9681-2ee13e016157)

- Clicking the link in the email will navigate the user to the Reset Password Page, where they can enter a new password.
![image](https://github.com/user-attachments/assets/e83a2428-ec50-4401-a28f-f8ad305956c3)

- If an error occur during the process, the error message will be shown.
![image](https://github.com/user-attachments/assets/7d863c79-db62-43ca-a9e6-0ca7fd6151fb)

- If the reset is successful, the user will be navigated to the reset success page. On this page, the user can directly click the "Back to Login" button to log in on the Login Page.
![image](https://github.com/user-attachments/assets/1cd114e7-35a9-45db-9d6b-b9eb5508ca34)

- During the process, users can always click the "Login" text at the bottom to return to the login page.
<img width="529" alt="image" src="https://github.com/user-attachments/assets/d640bba7-a63c-4cbd-8d4b-f382d4366e9b">

## Any notes?

<!--
  New PR Checklist

- Have you tag the right reviewer?
- Have you dm the reviewer?
- Maybe @ the reviewer in channel just to be safe

- is CI passing in your pr?
- Have you update the ticket with the right status?
-->
