### PR TITLE
Feat: CP-109 Replicate dashboard charts from legacy UI to current project

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -26,8 +26,9 @@
     "prettier-plugin-tailwindcss": "^0.6.5",
     "react": "^18",
     "react-dom": "^18",
-    "react-hook-form": "^7.52.1",
-    "react-icons": "^5.2.1",
+    "react-hook-form": "^7.53.0",
+    "react-icons": "^5.3.0",
+    "recharts": "^2.12.7",
     "tailwind-merge": "^2.5.2",
     "zod": "^3.23.8",
     "zustand": "^4.5.4"

--- a/apps/client/src/app/[locale]/(protected)/dashboard/components/CardComponent.tsx
+++ b/apps/client/src/app/[locale]/(protected)/dashboard/components/CardComponent.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import React, { useState } from 'react';
+import { BarChart, Bar, Cell, ResponsiveContainer } from 'recharts';
+import { MdTrendingUp } from 'react-icons/md';
+
+type Props = {
+  title: string;
+  subtitle?: string;
+  theme: "red" | "blue" | "green";
+  hideIcon?: boolean;
+  isSubtitleStyle?: boolean;
+  customClass?: string; 
+  titleColor?: string;
+} & (
+  | {
+      type: "percentage";
+      percentage: number;
+    }
+  | {
+      type: "bar-chart";
+      data: Array<{ id: number; name: string; pv: number }>;
+    }
+);
+
+const themeColors = {
+  red: {
+    textColor: "#FF4861",
+    gradient: "linear-gradient(to right, #FF4861, #ff7e9a)",
+  },
+  blue: {
+    textColor: "#48b5ff",
+    gradient: "linear-gradient(to right, #48b5ff, #7edbff)",
+  },
+  green: {
+    textColor: "#4CE1B6",
+    gradient: "linear-gradient(to right, #4CE1B6, #a6efda)",
+  },
+};
+
+const CardComponent: React.FC<Props> = ({
+  title,
+  subtitle,
+  theme,
+  hideIcon = false,
+  isSubtitleStyle = false,
+  customClass = "", 
+  titleColor, 
+  type,
+  ...rest
+}) => {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const handleBarClick = (e: any) => {
+    if (e && e.activePayload && e.activePayload.length) {
+      const item = e.activePayload[0].payload;
+      const index = (rest as { data: Array<{ id: number; name: string; pv: number }> }).data.findIndex(
+        (entry) => entry.name === item.name
+      );
+      setActiveIndex(index);
+    }
+  };
+
+  return (
+    <div className={`col-span-1 xl:col-span-1 lg:col-span-2 md:col-span-3 ${customClass}`}>
+      <div className={`bg-white pt-[25px] pb-[38px] px-[25px] rounded-lg shadow-[0_10px_30px_1px_rgba(0,0,0,0.06)] ${customClass}`}>
+        <div className="flex justify-between items-center mb-1">
+          <h2
+            className={`${
+              isSubtitleStyle
+                ? "text-sm font-medium opacity-70 uppercase"
+                : "text-2xl font-medium"
+            } font-sans`}
+            style={{ color: titleColor || themeColors[theme].textColor }} 
+          >
+            {title}
+          </h2>
+          {!hideIcon && <MdTrendingUp className="text-gray-300 w-6 h-6" />}
+        </div>
+
+        {subtitle && (
+          <h5 className="text-sm font-medium text-left opacity-70 mt-[-4px] uppercase text-primary-600 font-sans">
+            {subtitle}
+          </h5>
+        )}
+
+        {type === "percentage" ? (
+          <div className="relative pt-4 mt-1">
+            <div className="overflow-hidden h-2 text-xs flex rounded-full bg-[#dddddd]">
+              <div
+                className="h-full rounded-full"
+                style={{
+                  width: `${(rest as { percentage: number }).percentage}%`,
+                  background: themeColors[theme].gradient,
+                }}
+              ></div>
+            </div>
+            <p
+              className="absolute right-0 top-0 translate-y-[-50%] text-md font-sans"
+              style={{ color: themeColors[theme].textColor }}
+            >
+              {(rest as { percentage: number }).percentage}%
+            </p>
+          </div>
+        ) : (
+          <div className="flex items-end justify-between">
+            <p
+              className="text-[30px] font-sans mb-[-7px] mr-4"
+              style={{ color: themeColors[theme].textColor }}
+            >
+              {(rest as { data: Array<{ id: number; name: string; pv: number }> }).data[activeIndex].pv}
+            </p>
+            <div className="w-full lg:w-[55%] mt-[18px]">
+              <ResponsiveContainer width="100%" height={50}>
+                <BarChart
+                  data={(rest as { data: Array<{ id: number; name: string; pv: number }> }).data}
+                  onClick={handleBarClick}
+                >
+                  <Bar dataKey="pv">
+                    {(rest as { data: Array<{ id: number; name: string; pv: number }> }).data.map((entry, index) => (
+                      <Cell
+                        key={`cell-${index}`}
+                        cursor="pointer"
+                        fill={index === activeIndex ? themeColors[theme].textColor : "#c88ffa"}
+                      />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default CardComponent;

--- a/apps/client/src/app/[locale]/(protected)/dashboard/components/PendingOrders.tsx
+++ b/apps/client/src/app/[locale]/(protected)/dashboard/components/PendingOrders.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import CardComponent from './CardComponent';
+const PendingOrders = () => (
+  <CardComponent 
+    title="25" 
+    subtitle="Pending orders" 
+    theme="green" 
+    type="percentage" 
+    percentage={50} 
+  />
+);
+
+export default PendingOrders;

--- a/apps/client/src/app/[locale]/(protected)/dashboard/components/RecentTransactions.tsx
+++ b/apps/client/src/app/[locale]/(protected)/dashboard/components/RecentTransactions.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import CardComponent from './CardComponent'; 
+
+const data = [
+  { id: 0, name: 'Page A', pv: 255 },
+  { id: 1, name: 'Page B', pv: 452 },
+  { id: 2, name: 'Page C', pv: 154 },
+  { id: 3, name: 'Page D', pv: 85 },
+  { id: 4, name: 'Page E', pv: 545 },
+  { id: 5, name: 'Page F', pv: 438 },
+  { id: 6, name: 'Page G', pv: 523 },
+];
+
+const RecentTransactions = () => {
+  return (
+      <CardComponent
+        title="Recent Transactions"
+        theme="green"
+        type="bar-chart"
+        data={data}
+        hideIcon={true}
+        isSubtitleStyle={true}
+        customClass="pb-[26px]" 
+        titleColor="#787985"
+      />
+  );
+};
+
+export default RecentTransactions;

--- a/apps/client/src/app/[locale]/(protected)/dashboard/components/TotalAssets.tsx
+++ b/apps/client/src/app/[locale]/(protected)/dashboard/components/TotalAssets.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import CardComponent from './CardComponent';
+
+const TotalAssets = () => (
+  <CardComponent 
+    title="$878,372" 
+    subtitle="Total assets" 
+    theme="blue" 
+    type="percentage" 
+    percentage={18} 
+  />
+);
+
+export default TotalAssets;

--- a/apps/client/src/app/[locale]/(protected)/dashboard/components/TotalProfitEarned.tsx
+++ b/apps/client/src/app/[locale]/(protected)/dashboard/components/TotalProfitEarned.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import CardComponent from './CardComponent';
+
+const TotalProfitEarned = () => (
+  <CardComponent
+    title="$165,832"
+    subtitle="Total profit earned"
+    theme="red"
+    type="percentage"
+    percentage={27}
+  />
+);
+
+export default TotalProfitEarned;

--- a/apps/client/src/app/[locale]/(protected)/dashboard/page.tsx
+++ b/apps/client/src/app/[locale]/(protected)/dashboard/page.tsx
@@ -1,7 +1,21 @@
 import { DashboardRoute } from "@src/module/dashboard/route";
+import TotalProfitEarned from '@src/app/[locale]/(protected)/dashboard/components/TotalProfitEarned';
+import TotalAssets from '@src/app/[locale]/(protected)/dashboard/components/TotalAssets';
+import PendingOrders from '@src/app/[locale]/(protected)/dashboard/components/PendingOrders';
+import RecentTransactions from '@src/app/[locale]/(protected)/dashboard/components/RecentTransactions';
 
 export const metadata = DashboardRoute.Root.Metadata;
 
 export default function Page() {
-  return <div className="ring-1">Yeaaahh dashboard</div>;
+  return (
+    <div className="px-0 mx-0">
+      <h1 className="text-[20px] font-sans text-primary-700 mb-8">BeeQuant Dashboard</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-7"> 
+          <TotalProfitEarned />
+          <TotalAssets />
+          <PendingOrders />
+          <RecentTransactions />
+        </div>
+    </div>
+  );
 }


### PR DESCRIPTION
Completed the following changes:
Client:

Replicated dashboard charts for total profit, total assets, pending orders, and recent transactions. Ensured consistent layout, colors, and data bindings with the legacy UI. Updated ResponsiveContainer and BarChart settings to match design specifications. Aligned padding, margin, and grid classes across all dashboard cards. Validated that visual representation matches the original implementation, ensuring seamless user experience. Adjusted z-index and pointer-events settings to resolve click issues on chart interactions. 
Resolve CP-109
<img width="1280" alt="2fa0d2ae727d31529c56d3a0a1b0920" src="https://github.com/user-attachments/assets/7650dfa1-8efd-48de-86e1-33e04992bffb">
<img width="1280" alt="9109dcda34fcf94af780161c4d5471a" src="https://github.com/user-attachments/assets/0063a71e-6264-4144-9bd3-685417fed25e">

<!-- link to tickets -->

---

## What happens here?

## How do I know this is working?

## Any notes?

<!--
  New PR Checklist

- Have you tag the right reviewer?
- Have you dm the reviewer?
- Maybe @ the reviewer in channel just to be safe

- is CI passing in your pr?
- Have you update the ticket with the right status?
-->
