### PR TITLE
fix: adjust z-index of sidebar and header to ensure header on top

### DIFF
--- a/apps/client/src/module/dashboard/layout/header.tsx
+++ b/apps/client/src/module/dashboard/layout/header.tsx
@@ -5,7 +5,7 @@ import { SidebarToggleButton } from "./sidebar";
 
 export function Header() {
   return (
-    <header className="h-header dark:bg-primary-900 bg-primary-50 shadow-header z-20 flex items-center transition-colors duration-300">
+    <header className="h-header dark:bg-primary-900 bg-primary-50 shadow-header z-50 flex items-center transition-colors duration-300">
       <SidebarToggleButton />
 
       <DashboardRoute.Root.Link>

--- a/apps/client/src/module/dashboard/layout/sidebar.tsx
+++ b/apps/client/src/module/dashboard/layout/sidebar.tsx
@@ -30,7 +30,7 @@ export function SidebarContainer() {
     <div
       data-status={showSidebar ? "expanded" : "collapsed"}
       className={clsx(
-        "top-header peer/sidebar group/container shadow-sidebar dark:bg-primary-900 bg-primary-50 absolute bottom-0 z-50 overflow-hidden py-[15px] transition-[width_background-color] duration-300 md:overflow-visible",
+        "top-header peer/sidebar group/container shadow-sidebar dark:bg-primary-900 bg-primary-50 absolute bottom-0 z-40 overflow-hidden py-[15px] transition-[width_background-color] duration-300 md:overflow-visible",
         "data-[status=expanded]:w-sidebar-expanded data-[status=collapsed]:md:w-sidebar-collapsed w-0 duration-300 data-[status=collapsed]:w-0",
       )}
     >


### PR DESCRIPTION
[CP-137](https://beequant.atlassian.net/browse/CP-137)

---

## What happens here?
**Modified the z-index values of the sidebar and header to ensure that the header displays on top, to avoid sidebar's shadow overlapping the header.**

before:
![image](https://github.com/user-attachments/assets/0a234308-2560-4010-8d62-7a1db6f66316)

after:
![image](https://github.com/user-attachments/assets/4339328f-ec89-442d-82f4-fa258aedaeb3)

before:
![image](https://github.com/user-attachments/assets/5f9b0958-3c43-4ee9-ab30-7ff39a77aeb0)

after:
![image](https://github.com/user-attachments/assets/1feb9c02-62a7-4aac-9449-51e0a992ac16)

## How do I know this is working?
After logging in, go to the dashboard interface and check the overlapping relationships in the top left corner.

## Any notes?

<!--
  New PR Checklist

- Have you tag the right reviewer?
- Have you dm the reviewer?
- Maybe @ the reviewer in channel just to be safe

- is CI passing in your pr?
- Have you update the ticket with the right status?
-->
