### PR TITLE
feat: add loading animations to sign-in and sign-up buttons

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -30,6 +30,7 @@
     "react-icons": "^5.3.0",
     "recharts": "^2.12.7",
     "tailwind-merge": "^2.5.2",
+    "tw-elements": "^2.0.0",
     "zod": "^3.23.8",
     "zustand": "^4.5.4"
   },

--- a/apps/client/src/app/[locale]/(protected)/dashboard/components/RecentTransactions.tsx
+++ b/apps/client/src/app/[locale]/(protected)/dashboard/components/RecentTransactions.tsx
@@ -21,7 +21,7 @@ const RecentTransactions = () => {
         hideIcon={true}
         isSubtitleStyle={true}
         titleColor="#787985"
-        customPaddingBottom="27px"
+        customPaddingBottom="26px"
       />
   );
 };

--- a/apps/client/src/module/auth/register-form.tsx
+++ b/apps/client/src/module/auth/register-form.tsx
@@ -20,6 +20,7 @@ import { useState } from "react";
 export function RegisterForm() {
   const t = useTranslations();
   const passwordSchema = passwordValidationSchema(t);
+  const [loading, setLoading] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
 
   type FormSchema = z.infer<typeof formSchema>;
@@ -68,12 +69,19 @@ export function RegisterForm() {
   });
 
   async function action(payload: RegisterPayload) {
-    const res = await register(payload);
+    setLoading(true); 
+    try {
+      const res = await register(payload);
 
-    if (res?.success) {
-      setIsSuccess(true);
-    } else if (res?.error) {
-      setError("root", { message: getErrorMessage(res.error) });
+      if (res?.success) {
+        setIsSuccess(true); 
+      } else if (res?.error) {
+        setError("root", { message: getErrorMessage(res.error) });
+      }
+    } catch (error) {
+      setError("root", { message: t("Notifications.error.unknown") });
+    } finally {
+      setLoading(false); 
     }
   }
 
@@ -107,55 +115,68 @@ export function RegisterForm() {
   }
 
   return (
-    <AuthFormContainer onSubmit={onSubmit} error={errors.root?.message}>
-      <ControlledTextInput
-        label={t("Shared.displayName", { optional: true })}
-        tooltips={t("Notifications.displayName.description", {
-          optional: true,
-        })}
-        name="displayName"
-        control={control}
-        leftElement={<Icon icon="person" />}
-      />
-      <ControlledTextInput
-        label={t("Shared.email")}
-        name="email"
-        control={control}
-        leftElement={<Icon icon="person" />}
-        autoComplete="email"
-      />
-      <ControlledPasswordInput
-        label={t("Shared.password")}
-        tooltips={t("Notifications.password.description")}
-        name="password"
-        control={control}
-        autoComplete="new-password"
-      />
-      <ControlledPasswordInput
-        label={t("Shared.confirmPassword")}
-        name="confirmPassword"
-        control={control}
-        autoComplete="new-password"
-      />
+    <>
+      {loading && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-white bg-opacity-75">
+          <div
+            className="inline-block h-16 w-16 animate-spin rounded-full border-8 border-solid border-blue-500 border-t-transparent"
+            role="status"
+          >
+          </div>
+        </div>
+      )}
 
-      <ControlledTextInput
-        label={t("Shared.ref")}
-        name="ref"
-        control={control}
-        leftElement={<Icon icon="person" />}
-        disabled
-      />
+      <AuthFormContainer onSubmit={onSubmit} error={errors.root?.message}>
+        <ControlledTextInput
+          label={t("Shared.displayName", { optional: true })}
+          tooltips={t("Notifications.displayName.description", {
+            optional: true,
+          })}
+          name="displayName"
+          control={control}
+          leftElement={<Icon icon="person" />}
+        />
+        <ControlledTextInput
+          label={t("Shared.email")}
+          name="email"
+          control={control}
+          leftElement={<Icon icon="person" />}
+          autoComplete="email"
+        />
+        <ControlledPasswordInput
+          label={t("Shared.password")}
+          tooltips={t("Notifications.password.description")}
+          name="password"
+          control={control}
+          autoComplete="new-password"
+        />
+        <ControlledPasswordInput
+          label={t("Shared.confirmPassword")}
+          name="confirmPassword"
+          control={control}
+          autoComplete="new-password"
+        />
 
-      <Button type="submit" className="my-5">
-        {t("RegisterPage.signUp")}
-      </Button>
+        <ControlledTextInput
+          label={t("Shared.ref")}
+          name="ref"
+          control={control}
+          leftElement={<Icon icon="person" />}
+          disabled
+        />
 
-      <span className="text-center text-[13px]">
-        {t("RegisterPage.alreadyHaveAccount")}{" "}
-        <AuthRoute.Login.Link className="text-accent-400 hover:text-accent-400">
-          {t("Shared.signIn")}
-        </AuthRoute.Login.Link>
-      </span>
-    </AuthFormContainer>
+        {/* SignUp button with loading */}
+        <Button type="submit" className="my-5" disabled={loading}>
+          {loading ? t("Shared.loading") : t("RegisterPage.signUp")}
+        </Button>
+
+        <span className="text-center text-[13px]">
+          {t("RegisterPage.alreadyHaveAccount")}{" "}
+          <AuthRoute.Login.Link className="text-accent-400 hover:text-accent-400">
+            {t("Shared.signIn")}
+          </AuthRoute.Login.Link>
+        </span>
+      </AuthFormContainer>
+    </>
   );
 }


### PR DESCRIPTION
- Implemented loading animations for sign-in and sign-up buttons during API fetch and mutation.
- Change the highet of 4th card on dashboard from 140px to 139px.

Resolve CP-129

<img width="290" alt="image" src="https://github.com/user-attachments/assets/de7b590c-d875-439b-be07-593a950692b4">

<!-- link to tickets -->

---

## What happens here?

## How do I know this is working?

## Any notes?

<!--
  New PR Checklist

- Have you tag the right reviewer?
- Have you dm the reviewer?
- Maybe @ the reviewer in channel just to be safe

- is CI passing in your pr?
- Have you update the ticket with the right status?
-->
