### PR TITLE
Fixed focus behavior of the prompt text in the register page

### DIFF
--- a/apps/client/src/module/account/setting/setting-form.tsx
+++ b/apps/client/src/module/account/setting/setting-form.tsx
@@ -132,7 +132,7 @@ export function AccountSettingForm() {
       >
         <form
           onSubmit={handleSubmit(onSubmit)}
-          className="flex flex-col sm:gap-y-12 md:gap-y-8 xl:gap-y-6"
+          className="mt-[30px] flex flex-col gap-y-5"
         >
           <ControlledTextInput
             direction="horizontal"

--- a/apps/client/src/module/common/button.tsx
+++ b/apps/client/src/module/common/button.tsx
@@ -59,6 +59,7 @@ export function Button({
 }: Props) {
   return (
     <button
+      onMouseDown={(e) => e.preventDefault()}
       className={buttonVariants({
         variant,
         size,

--- a/apps/client/src/module/common/controlled-input.tsx
+++ b/apps/client/src/module/common/controlled-input.tsx
@@ -1,7 +1,6 @@
-"use client";
 import { useToggle } from "@src/utils";
 import clsx from "clsx";
-import React, { InputHTMLAttributes, useState } from "react";
+import React, { InputHTMLAttributes } from "react";
 import { Control, FieldPath, useController } from "react-hook-form";
 import { Icon } from "./icon";
 import { cva, type VariantProps } from "class-variance-authority";
@@ -31,7 +30,6 @@ type ControlledInputProps<TFieldValues extends object = object> = {
   rightElement?: React.ReactNode;
 } & InputHTMLAttributes<HTMLInputElement> &
   InputVariants;
-
 export function ControlledTextInput<TFieldValues extends object>({
   label,
   name,
@@ -50,16 +48,22 @@ export function ControlledTextInput<TFieldValues extends object>({
     name,
     control,
   });
-
-  const [isFocused, setIsFocused] = useState(false);
-
   return (
-    <label
-      className={inputVariants({ direction })}
-      style={{ position: "relative" }}
-    >
-      <span>{label}</span>
+    <label className={inputVariants({ direction })}>
+      <span>
+        {label}
+        {!!tooltips && direction === "vertical" && (
+          <span className="text-accent-400 hidden group-focus-within:inline">
+            {tooltips}
+          </span>
+        )}
+      </span>
       <div className={clsx(!!tooltips && "flex flex-col")}>
+        {!!tooltips && direction === "horizontal" && (
+          <span className="text-accent-400 hidden space-y-1 group-focus-within:inline">
+            {tooltips}
+          </span>
+        )}
         <div className="relative flex items-stretch">
           {!!leftElement && (
             <span className="bg-primary-100 text-primary-300 p-2 transition-colors duration-300 dark:bg-[#33333a]">
@@ -67,36 +71,12 @@ export function ControlledTextInput<TFieldValues extends object>({
             </span>
           )}
           <input
-            className={clsx(
-              "focus:shadow-accent-400 dark:focus:shadow-accent-400 shadow-primary-100 dark:shadow-primary-700 shadow-inset flex-1 bg-transparent px-2 py-1 text-sm transition-[box-shadow] duration-300 placeholder:text-xs focus:outline-none",
-              inputVariants({ className }),
-            )}
+            className="focus:shadow-accent-400 dark:focus:shadow-accent-400 shadow-primary-100 dark:shadow-primary-700 shadow-inset flex-1 bg-transparent px-2 py-1 text-xs transition-[box-shadow] duration-300 placeholder:text-xs focus:outline-none"
             placeholder={label ? label : props.placeholder}
             {...props}
             {...field}
-            onFocus={(e) => {
-              setIsFocused(true);
-              if (props.onFocus) props.onFocus(e);
-            }}
-            onBlur={(e) => {
-              setIsFocused(false);
-              if (props.onBlur) props.onBlur(e);
-              field.onBlur();
-            }}
           />
           {!!rightElement && rightElement}
-
-          {!!tooltips && isFocused && (
-            <span
-              className="text-accent-400 absolute left-0 top-0 rounded px-2 py-1 text-sm"
-              style={{
-                transform: "translateY(-90%)",
-                marginLeft: direction === "horizontal" ? "25px" : "0",
-              }}
-            >
-              {tooltips}
-            </span>
-          )}
 
           {error?.message && (
             <span


### PR DESCRIPTION
In the registration page, the prompt text caused focus loss when clicking the button, preventing proper interaction.  This commit ensures that the input remains focused even when clicking the button, allowing the button to be clicked without losing focus.

CP-147

![image](https://github.com/user-attachments/assets/fff310f5-ebaa-49ae-b3a8-c012cb837955)

<!-- link to tickets -->

---

## What happens here?

## How do I know this is working?

## Any notes?

<!--
  New PR Checklist

- Have you tag the right reviewer?
- Have you dm the reviewer?
- Maybe @ the reviewer in channel just to be safe

- is CI passing in your pr?
- Have you update the ticket with the right status?
-->
